### PR TITLE
Ignore JSON metadata field for now.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ jobs:
       uses: hecrj/setup-rust-action@v1
       with:
         rust-version: ${{ matrix.rust }}
-    - if: matrix.rust != 'nightly'
+    - if: matrix.rust == 'stable'
       run: rustup component add clippy
-    - if: matrix.rust != 'nightly'
+    - if: matrix.rust == 'stable'
       run: cargo clippy -- -D warnings
     - run: cargo build --verbose
     - run: cargo test --verbose

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,10 +6,15 @@ Breaking Changes
 
 New
 
+* The JSON unit ignores the `metadata` field in received files. This
+  makes it compatible with the JSON produced by at least Routinator, OctoRPKI,
+  and rpki-client. ([#8])
+
 Bug Fixes
 
 Other Changes
 
+[#8]: https://github.com/NLnetLabs/rtrtr/pull/8
 
 
 ## 0.1.1 ‘Death Metal Karaoke’

--- a/src/formats/json.rs
+++ b/src/formats/json.rs
@@ -199,13 +199,6 @@ impl<'de> Deserialize<'de> for Prefix {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 struct Metadata {
-    counts: usize,
-    generated: u64,
-    valid: u64,
-    signature: String,
-
-    #[serde(rename = "signatureDate")]
-    signature_date: String,
 }
 
 
@@ -344,6 +337,9 @@ mod test {
         ).unwrap());
         check_set(serde_json::from_slice::<Set>(
             include_bytes!("../../test-data/vrps-metadata.json")
+        ).unwrap());
+        check_set(serde_json::from_slice::<Set>(
+            include_bytes!("../../test-data/vrps-metadata.rpki-client.json")
         ).unwrap());
     }
 }

--- a/src/log.rs
+++ b/src/log.rs
@@ -132,6 +132,7 @@ impl LogConfig {
     ///
     /// This is the non-Unix version that does not use syslog.
     #[cfg(not(unix))]
+    #[allow(clippy::unnecessary_wraps)]
     fn apply_log_matches(
         &mut self,
         matches: &ArgMatches,

--- a/test-data/vrps-metadata.rpki-client.json
+++ b/test-data/vrps-metadata.rpki-client.json
@@ -1,0 +1,38 @@
+{
+    "roas": [
+        {
+            "asn": "AS64512",
+            "prefix": "192.0.2.0/24",
+            "maxLength": 24,
+            "ta": "ta"
+        },
+        {
+            "asn": "AS4200000000",
+            "prefix": "2001:DB8::/32",
+            "maxLength": 32,
+            "ta": "ta"
+        }
+    ],
+    "metadata": {
+		"buildmachine": "rpki-client",
+		"buildtime": "2020-12-11T22:18:15Z",
+		"elapsedtime": "218",
+		"usertime": "116",
+		"systemtime": "68",
+		"roas": 56977,
+		"failedroas": 8,
+		"invalidroas": 0,
+		"certificates": 22207,
+		"failcertificates": 0,
+		"invalidcertificates": 0,
+		"tals": 5,
+		"talfiles": "/etc/tals/apnic.tal /etc/tals/arin.tal /etc/tals/ripe.tal /etc/tals/lacnic.tal /etc/tals/afrinic.tal",
+		"manifests": 22207,
+		"failedmanifests": 10,
+		"stalemanifests": 0,
+		"crls": 22197,
+		"repositories": 29,
+		"vrps": 210413,
+		"uniquevrps": 207098
+    }
+}


### PR DESCRIPTION
Different software seems to produce different content for the `metadata` field in the JSON format. Since we currently are not using any of it, we might as well ignore it.

Fixes #7.