### PR TITLE
Initial Dockerfile and accompanying README changes.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+# -- stage 1: build static rtrtr with musl libc for alpine
+FROM alpine:3.13.0 as build
+
+RUN apk add rust cargo
+
+WORKDIR /tmp/rtrtr
+COPY . .
+
+RUN cargo build \
+    --target x86_64-alpine-linux-musl \
+    --release \
+    --locked
+
+# -- stage 2: create alpine-based container with the static rtrtr
+#             executable
+FROM alpine:3.13.0
+COPY --from=build /tmp/rtrtr/target/x86_64-alpine-linux-musl/release/rtrtr /usr/local/bin/
+
+# Build variables for uid and guid of user to run container
+ARG RUN_USER=rtrtr
+ARG RUN_USER_UID=1012
+ARG RUN_USER_GID=1012
+
+# Install rsync as rtrtr depends on it
+RUN apk add --no-cache rsync libgcc
+
+# Use Tini to ensure that Routinator responds to CTRL-C when run in the
+# foreground without the Docker argument "--init" (which is actually another
+# way of activating Tini, but cannot be enabled from inside the Docker image).
+RUN apk add --no-cache tini
+# Tini is now available at /sbin/tini
+
+RUN addgroup -g ${RUN_USER_GID} ${RUN_USER} && \
+    adduser -D -u ${RUN_USER_UID} -G ${RUN_USER} ${RUN_USER}
+
+USER $RUN_USER_UID
+
+# Expose the default metrics port
+EXPOSE 8080/tcp
+
+# Expose the default data serving port
+EXPOSE 9001/tcp
+
+ENTRYPOINT ["/sbin/tini", "--", "rtrtr"]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ a config file. An example can be found in [`etc/rtrtr.conf`]. For the
 moment, this example file also serves as a manual for the available
 components and their configuration.
 
-
 ## Quick Start
 
 If you have already installed Routinator, this should all be somewhat
@@ -63,3 +62,54 @@ rtrtr -c rtrtr.conf
 ```
 
 [`etc/rtrtr.conf`]: https://github.com/NLnetLabs/rtrtr/blob/main/etc/rtrtr.conf
+
+## Using Docker
+
+To run RTRTR with Docker you will first need to create an `rtrtr.conf` file
+somewhere on your host computer and make that available to the Docker container
+when you run it. For example if your config file is in `/etc/rtrtr.conf` on the
+host computer:
+
+```bash
+docker run -v /etc/rtrtr.conf:/etc/rtrtr.conf nlnetlabs/rtrtr -c /etc/rtrtr.conf
+```
+
+RTRTR will need network access to fetch and publish data according to the
+configured units and targets respectively. Explaining Docker networking is beyond
+the scope of this README, however below are a couple of examples to get you
+started.
+
+If you need an RTRTR unit to fetch data from a source port on the host you will
+also need to give the Docker container access to the host network. For example
+one way to do this is with `--net=host`:
+
+```bash
+docker run --net=host ...
+```
+_(where ... represents the rest of the arguments to pass to Docker and RTRTR)_
+
+This will also cause any configured RTRTR target ports to be published on the
+host network interface.
+
+If you're not using `--net=host` you will need to tell Docker to expoee the
+RTRTR target ports, either one by one using `-p`, or you can publish the default
+ports exposed by the Docker container (and at the same time remap them to high
+numbered ports) using `-P`. E.g.
+
+```bash
+docker run -p 8080:8080/tcp -p 9001:9001/tcp ...
+```
+
+Or:
+
+```bash
+docker run -P ...
+```
+
+You can verify which ports are exposed using the `docker ps` command which should
+show something like this:
+```bash
+CONTAINER ID   IMAGE             COMMAND                  CREATED          STATUS          PORTS                                              NAMES
+146237ba9b4b   nlnetlabs/rtrtr   "/sbin/tini -- rtrtr…"   16 seconds ago   Up 14 seconds   0.0.0.0:49154->8080/tcp, 0.0.0.0:49153->9001/tcp   zealous_tesla
+```
+_(the output in this example shows the high-numbered port mapping that occurs when using `docker run -P`)_


### PR DESCRIPTION
Based on the Routinator Dockerfile.

If we want to publish to Docker Hub we can do a manual push or setup automatic publishing at Docker Hub as we have for Routinator.

The user must provide their own `rtrtr.conf` file because there are no sensible default settings for RTRTR, it's entirely dependent on the operators setup and needs.