### PR TITLE
Explicitely set listener sockets to non-blocking.

### DIFF
--- a/src/targets/rtr.rs
+++ b/src/targets/rtr.rs
@@ -59,6 +59,13 @@ impl Tcp {
                 return Err(ExitError)
             }
         };
+        if let Err(err) = listener.set_nonblocking(true) {
+            error!(
+                "Fatal: failed to set listener {} to non-blocking: {}.",
+                addr, err
+            );
+            return Err(ExitError);
+        }
         let listener = match TcpListener::from_std(listener) {
             Ok(listener) => listener,
             Err(err) => {


### PR DESCRIPTION
This was missing when upgrading to Tokio 1.0 resulting in blockages.