### PR TITLE
Make --config mandatory.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -63,6 +63,7 @@ impl Config {
         let app = app.arg(Arg::with_name("config")
                 .short("c")
                  .long("config")
+                 .required(true)
                  .takes_value(true)
                  .value_name("PATH")
                  .help("Read base configuration from this file")


### PR DESCRIPTION
Previously, it wasn’t marked as mandatory but leaving it out let to a panic.