### PR TITLE
Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+/target
+.git


### PR DESCRIPTION
Don't send potentially large unnecessary directory contents to the Docker daemon when building the Docker image