### PR TITLE
Re-enable Buster package testing (closes #26).

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -408,7 +408,7 @@ jobs:
           - "ubuntu:bionic"   # ubuntu/18.04
           - "ubuntu:focal"    # ubuntu/20.04
           - "debian:stretch"  # debian/9
-          #- "debian:buster"   # debian/10 (disabled, see issue #26)
+          - "debian:buster"   # debian/10 (disabled, see issue #26)
           - "debian:bullseye" # debian/11
           - "centos:7"
           - "centos:8"


### PR DESCRIPTION
As part of following up on #26 I decided to re-test the part that was previously failing... and it no longer seems to be failing...

Here are two new runs of the workflow which both successfully test the created package on Debian Buster which was failing in #26 for reasons seemingly unrelated to anything we are doing:

- https://github.com/NLnetLabs/rtrtr/actions/runs/1876043104
- https://github.com/NLnetLabs/rtrtr/actions/runs/1876146320

Since it seems to be working this PR re-enables the Debian Buster package test.

Note however that it won't pass until yet another unrelated (but this time clearly transient) 3rd party issue is resolved: https://discuss.linuxcontainers.org/t/image-copy-from-images-ubuntu-focal-cloud-got-503-service-unavailable/13429/3

The two successful runs linked to above contain a temporary workaround for this issue with linuxcontainers.org which deliberately isn't included in this PR.

Once https://images.linuxcontainers.org/streams/v1/index.json is working again we can merge this PR.