### PR TITLE
Add a merge unit.

### DIFF
--- a/src/units/mod.rs
+++ b/src/units/mod.rs
@@ -36,6 +36,9 @@ pub enum Unit {
     #[serde(rename = "any")]
     Any(combine::Any),
 
+    #[serde(rename = "merge")]
+    Merge(combine::Merge),
+
     #[serde(rename = "rtr")]
     RtrTcp(rtr::Tcp),
 
@@ -55,6 +58,7 @@ impl Unit {
     )  {
         let _ = match self {
             Unit::Any(unit) => unit.run(component, gate).await,
+            Unit::Merge(unit) => unit.run(component, gate).await,
             Unit::RtrTcp(unit) => unit.run(component, gate).await,
             Unit::RtrTls(unit) => unit.run(component, gate).await,
             Unit::Json(unit) => unit.run(component, gate).await,


### PR DESCRIPTION
This new unit merges the content of the data sets from all configured upstream units.

Before we can, ehem, merge this, we need to add the ability for a unit to declare its data set outdated, so we don’t keep merging the data from a stalled unit. (Alternatively, units only stall once their data is considered outdated.)

Also, the internal use of serial numbers is inconsistent – I think we don’t actually need them at all.