### PR TITLE
Fix slurm unit start race.

### DIFF
--- a/src/units/slurm.rs
+++ b/src/units/slurm.rs
@@ -48,7 +48,7 @@ impl LocalExceptions {
         // Whether we are ready to submit an update to our gate.
         //
         // This will stay at false until we have received our first
-        // notification from the exception set inidcating that it loaded all
+        // notification from the exception set indicating that it loaded all
         // files.
         let mut ready = false;
         loop {


### PR DESCRIPTION
This PR fixes a race in the slurm unit that caused exceptions not processed if loading the files took too long. As a side-effect, the unit’s output will now be updated immediately when an update to the files has been detected rather than only be considered when the next update from the unit’s source comes in.

This fixes one part of #86.