### PR TITLE
Refactor communication to cleanly deal with start-up and shut-down.

### DIFF
--- a/src/comms.rs
+++ b/src/comms.rs
@@ -553,6 +553,12 @@ impl From<String> for Link {
     }
 }
 
+impl<'a> From<&'a str> for Link {
+    fn from(name: &'a str) -> Self {
+        Self::from(String::from(name))
+    }
+}
+
 
 //------------ GateStatus ----------------------------------------------------
 

--- a/src/comms.rs
+++ b/src/comms.rs
@@ -454,7 +454,7 @@ impl Link {
     /// unit’s new status as the error variant.
     ///
     /// If this method is called when the unit status is “gone,” the future
-    /// will never resolve. This helps
+    /// will never resolve.
     pub async fn query(&mut self) -> Result<&payload::Update, UnitStatus> {
         if self.connect().await {
             if !matches!(self.unit_status, UnitStatus::Healthy) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -387,7 +387,9 @@ pub struct ConfigPath(PathBuf);
 
 impl ConfigPath {
     thread_local!(
-        static BASE_PATH: RefCell<Option<PathBuf>> = RefCell::new(None)
+        static BASE_PATH: RefCell<Option<PathBuf>> = const {
+            RefCell::new(None)
+        }
     );
 
     fn set_base_path(path: PathBuf) {

--- a/src/formats/json.rs
+++ b/src/formats/json.rs
@@ -17,7 +17,6 @@
 //! When creating a JSON file, this minimal format will be used. The ASN will
 //! be represented as a string with the `AS` prefix.
 
-use std::convert::TryFrom;
 use rpki::resources::asn::Asn;
 use rpki::resources::addr::{MaxLenError, MaxLenPrefix, Prefix};
 use rpki::rtr::payload::{RouteOrigin, Payload, PayloadRef};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,5 +31,6 @@ pub mod log;
 pub mod manager;
 pub mod metrics;
 pub mod payload;
+pub mod test;
 pub mod targets;
 pub mod units;

--- a/src/log.rs
+++ b/src/log.rs
@@ -7,7 +7,6 @@
 //! indicate that error information has been logged and a consumer can just
 //! return quietly.
 use std::{fmt, io, process};
-use std::convert::TryFrom;
 use std::path::Path;
 use std::str::FromStr;
 use clap::{Arg, ArgMatches, Command};

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ fn _main() -> Result<(), ExitError> {
         .unwrap();
     let handle = runtime.handle();
     config.http.run(manager.metrics(), manager.http_resources(), &runtime)?;
-    manager.spawn(&mut config.units, &mut config.targets, &handle);
+    manager.spawn(&mut config.units, &mut config.targets, handle);
     runtime.block_on(pending())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,8 +35,9 @@ fn _main() -> Result<(), ExitError> {
         .enable_all()
         .build()
         .unwrap();
+    let handle = runtime.handle();
     config.http.run(manager.metrics(), manager.http_resources(), &runtime)?;
-    manager.spawn(&mut config, &runtime);
+    manager.spawn(&mut config.units, &mut config.targets, &handle);
     runtime.block_on(pending())
 }
 

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -165,12 +165,15 @@ impl Manager {
         Ok(config)
     }
 
-    /// Allows creating units and adding them to the manager.
+    /// Allows creating components and adding them to the manager.
     ///
-    /// Because creating units that contain links requires some setup work,
-    /// this has to happen inside a closure. This closure should return a
-    /// list of units 
-    pub fn add_units<F, T>(
+    /// Because creating components that contain links requires some setup
+    /// work, this has to happen inside a closure. Inside the closure, you
+    /// can create units and targets and add them to the correct set. Once
+    /// the closure returns, all of the units and targets are spawned onto
+    /// the runtime represented by the `runtime` handle. If all of this
+    /// succeeds, the method will return whatever the closure returned.
+    pub fn add_components<F, T>(
         &mut self, runtime: &runtime::Handle, op: F
     ) -> Result<T, Failed>
     where
@@ -189,7 +192,7 @@ impl Manager {
         let res = op(&mut units, &mut targets);
 
         // All entries in the thread-local that have a gate are new. They must
-        // appear in config’s units or we have unresolved links.
+        // appear in unit set or we have unresolved links.
         let gates = GATES.with(|gates| gates.replace(None)).unwrap();
         let mut errs = Vec::new();
         for (name, load) in gates {

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -235,6 +235,7 @@ impl Manager {
                     continue
                 }
             };
+            eprintln!("Spawning unit {}", name);
             let controller = Component::new(
                 name, self.http_client.clone(), self.metrics.clone(),
                 self.http_resources.clone()
@@ -243,12 +244,15 @@ impl Manager {
         }
 
         for (name, target) in targets.targets.drain() {
+            eprintln!("Spawning target {}", name);
             let controller = Component::new(
                 name, self.http_client.clone(), self.metrics.clone(),
                 self.http_resources.clone()
             );
             runtime.spawn(target.run(controller));
         }
+
+        eprintln!("Everything spawned.");
     }
 
     /// Returns a new reference to the manager’s metrics collection.

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -151,6 +151,7 @@ impl Manager {
                     }
                 }
                 else {
+                    self.units.insert(name.clone(), load.agent);
                     self.pending.insert(name, gate);
                 }
             }
@@ -203,6 +204,7 @@ impl Manager {
                     )
                 }
                 else {
+                    self.units.insert(name.clone(), load.agent);
                     self.pending.insert(name, gate);
                 }
             }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -235,7 +235,6 @@ impl Manager {
                     continue
                 }
             };
-            eprintln!("Spawning unit {}", name);
             let controller = Component::new(
                 name, self.http_client.clone(), self.metrics.clone(),
                 self.http_resources.clone()
@@ -244,7 +243,6 @@ impl Manager {
         }
 
         for (name, target) in targets.targets.drain() {
-            eprintln!("Spawning target {}", name);
             let controller = Component::new(
                 name, self.http_client.clone(), self.metrics.clone(),
                 self.http_resources.clone()
@@ -252,7 +250,6 @@ impl Manager {
             runtime.spawn(target.run(controller));
         }
 
-        eprintln!("Everything spawned.");
     }
 
     /// Returns a new reference to the manager’s metrics collection.
@@ -351,8 +348,9 @@ impl From<GateAgent> for LoadUnit {
 //------------ Loading Links -------------------------------------------------
 
 thread_local!(
-    static GATES: RefCell<Option<HashMap<String, LoadUnit>>> =
+    static GATES: RefCell<Option<HashMap<String, LoadUnit>>> = const {
         RefCell::new(None)
+    }
 );
 
 

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -1130,9 +1130,6 @@ impl DiffBuilder {
 //------------ Update --------------------------------------------------------
 
 /// An update of a unit’s payload data.
-///
-/// An update keeps both the set and optional diff behind an arc and can thus
-/// be copied cheaply.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Update {
     /// The new payload set.

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -1133,7 +1133,7 @@ impl DiffBuilder {
 ///
 /// An update keeps both the set and optional diff behind an arc and can thus
 /// be copied cheaply.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Update {
     /// The new payload set.
     set: Set,

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -1245,6 +1245,16 @@ pub(crate) mod testrig {
         }
     }
 
+    /// Creates an update from a bunch of integers
+    pub fn update(values: &[u32]) -> Update {
+        Update::new(
+            set(vec![
+                block(values, 0..values.len())
+            ])
+        )
+    }
+
+
     /// Converts a set into a vec of integers.
     pub fn set_to_vec(set: &Set) -> Vec<u32> {
         set.iter().map(|payload| match payload {

--- a/src/targets/http.rs
+++ b/src/targets/http.rs
@@ -137,7 +137,7 @@ struct SourceData {
 }
 
 impl SourceData {
-    fn new(update: payload::Update, state: &mut State) -> Self {
+    fn new(update: &payload::Update, state: &mut State) -> Self {
         let etag = format!("\"{:x}-{}\"", state.session(), state.serial());
         state.inc();
         Self {

--- a/src/targets/mod.rs
+++ b/src/targets/mod.rs
@@ -38,6 +38,10 @@ pub enum Target {
 
     #[serde(rename = "http")]
     Http(http::Target),
+
+    #[cfg(test)]
+    #[serde(skip)]
+    Test(crate::test::Target)
 }
 
 impl Target {
@@ -47,6 +51,9 @@ impl Target {
             Target::RtrTcp(target) => target.run(component).await,
             Target::RtrTls(target) => target.run(component).await,
             Target::Http(target) => target.run(component).await,
+
+            #[cfg(test)]
+            Target::Test(target) => target.run(component).await,
         }
     }
 }

--- a/src/targets/rtr.rs
+++ b/src/targets/rtr.rs
@@ -274,7 +274,7 @@ impl Source {
         }
     }
 
-    fn update(&self, update: payload::Update) {
+    fn update(&self, update: &payload::Update) {
         let data = self.data.load();
 
         let new_data = match data.current.as_ref() {

--- a/src/test.rs
+++ b/src/test.rs
@@ -137,7 +137,7 @@ async fn simple_comms() {
 
     let mut manager = Manager::new();
 
-    let (u, mut t) = manager.add_units(
+    let (u, mut t) = manager.add_components(
         &runtime::Handle::current(),
         |units, targets| {
             let (u, uc) = Unit::new();

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,0 +1,129 @@
+//! Helpful things for testing.
+#![cfg(test)]
+
+use tokio::sync::mpsc;
+use crate::{targets, units};
+use crate::comms::{Gate, Link, Terminated, UnitStatus};
+use crate::payload;
+use crate::log::ExitError;
+use crate::manager::Component;
+
+
+//------------ Unit ----------------------------------------------------------
+
+/// A unit that only does what it is told.
+#[derive(Debug)]
+pub struct Unit {
+    rx: mpsc::Receiver<UnitCommand>,
+}
+
+impl Unit {
+    pub fn new() -> (units::Unit, UnitController) {
+        let (tx, rx) = mpsc::channel(10);
+        (units::Unit::Test(Self { rx }), UnitController { tx })
+    }
+
+    pub async fn run(
+        mut self, _component: Component, mut gate: Gate
+    ) -> Result<(), Terminated> {
+        while let Some(cmd) = gate.process_until(self.rx.recv()).await? {
+            match cmd {
+                UnitCommand::Data(update) => {
+                    gate.update_data(update).await
+                }
+                UnitCommand::Status(status) => {
+                    gate.update_status(status).await
+                }
+            }
+        }
+        Err(Terminated)
+    }
+}
+
+
+//------------ UnitController ------------------------------------------------
+
+/// A controller for telling the test unit what to do.
+#[derive(Clone, Debug)]
+pub struct UnitController {
+    tx: mpsc::Sender<UnitCommand>,
+}
+
+impl UnitController {
+    pub async fn update_data(&self, data: payload::Update) {
+        self.tx.send(
+            UnitCommand::Data(data)
+        ).await.expect("unit was terminated")
+    }
+
+    pub async fn update_status(&self, status: UnitStatus) {
+        self.tx.send(
+            UnitCommand::Status(status)
+        ).await.expect("unit was terminated")
+    }
+}
+
+
+//------------ UnitCommand ---------------------------------------------------
+
+/// A command sent by the unit controller.
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum UnitCommand {
+    Data(payload::Update),
+    Status(UnitStatus),
+}
+
+
+//------------ Target --------------------------------------------------------
+
+/// A target that allows checking what happened.
+#[derive(Debug)]
+pub struct Target {
+    link: Link,
+    tx: mpsc::UnboundedSender<UnitCommand>,
+}
+
+impl Target {
+    pub fn new(link: impl Into<Link>) -> (targets::Target, TargetController) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        (
+            targets::Target::Test(Self { link: link.into(), tx }),
+            TargetController { rx }
+        )
+    }
+
+    pub async fn run(
+        mut self, _component: Component,
+    ) -> Result<(), ExitError> {
+        loop {
+            let cmd = match self.link.query().await {
+                Ok(data) => UnitCommand::Data(data),
+                Err(status) => UnitCommand::Status(status),
+            };
+            self.tx.send(cmd).expect("controller went away")
+        }
+    }
+}
+
+
+//------------ TargetController ----------------------------------------------
+
+#[derive(Debug)]
+pub struct TargetController {
+    rx: mpsc::UnboundedReceiver<UnitCommand>,
+}
+
+impl TargetController {
+    pub async fn assert_data_eq(
+        &mut self, data: payload::Update
+    ) {
+        assert_eq!(self.rx.recv().await.unwrap(), UnitCommand::Data(data))
+    }
+
+    pub async fn assert_status_eq(
+        &mut self, status: UnitStatus
+    ) {
+        assert_eq!(self.rx.recv().await.unwrap(), UnitCommand::Status(status))
+    }
+}
+

--- a/src/units/combine.rs
+++ b/src/units/combine.rs
@@ -193,7 +193,7 @@ mod test {
 
         let mut manager = Manager::new();
 
-        let (u1, u2, u3, mut t) = manager.add_units(
+        let (u1, u2, u3, mut t) = manager.add_components(
             &runtime::Handle::current(),
             |units, targets| {
                 let (u, u1c) = test::Unit::new();

--- a/src/units/combine.rs
+++ b/src/units/combine.rs
@@ -306,3 +306,44 @@ impl metrics::Source for AnyMetrics {
     }
 }
 
+
+//============ Tests =========================================================
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use tokio::runtime;
+    use crate::{test, units};
+    use crate::manager::Manager;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn wake_up_again() {
+        let mut manager = Manager::new();
+
+        let (_u1, _u2, _u3, _t) = manager.add_units(
+            &runtime::Handle::current(),
+            |units, targets| {
+                let (u, u1c) = test::Unit::new();
+                units.insert("u1", u);
+                let (u, u2c) = test::Unit::new();
+                units.insert("u2", u);
+                let (u, u3c) = test::Unit::new();
+                units.insert("u3", u);
+
+                units.insert("any", units::Unit::Any(Any {
+                    sources: vec!["u1".into(), "u2".into(), "u3".into()],
+                    random: false
+                }));
+
+                let (t, tc) = test::Target::new("any");
+                targets.insert("t", t);
+
+
+                (u1c, u2c, u3c, tc)
+            }
+        ).unwrap();
+
+        // XXX Do actual testing!
+    }
+}
+

--- a/src/units/mod.rs
+++ b/src/units/mod.rs
@@ -47,6 +47,10 @@ pub enum Unit {
 
     #[serde(rename = "slurm")]
     Slurm(slurm::LocalExceptions),
+
+    #[cfg(test)]
+    #[serde(skip)]
+    Test(crate::test::Unit),
 }
 
 impl Unit {
@@ -59,6 +63,9 @@ impl Unit {
             Unit::RtrTls(unit) => unit.run(component, gate).await,
             Unit::Json(unit) => unit.run(component, gate).await,
             Unit::Slurm(unit) => unit.run(component, gate).await,
+
+            #[cfg(test)]
+            Unit::Test(unit) => unit.run(component, gate).await,
         };
     }
 }

--- a/src/units/rtr.rs
+++ b/src/units/rtr.rs
@@ -5,7 +5,6 @@
 //! [`Tls`] uses TLS.
 
 use std::io;
-use std::convert::TryFrom;
 use std::fs::File;
 use std::future::Future;
 use std::pin::Pin;

--- a/src/units/slurm.rs
+++ b/src/units/slurm.rs
@@ -42,9 +42,6 @@ impl LocalExceptions {
             self.files.into_iter().map(Into::into).collect()
         );
 
-        // The data set we receive from the source.
-        let mut data = None;
-
         // Whether we are ready to submit an update to our gate.
         //
         // This will stay at false until we have received our first
@@ -57,9 +54,7 @@ impl LocalExceptions {
 
                 maybe_update = self.source.query() => {
                     match maybe_update {
-                        Ok(update) => {
-                            data = Some(update);
-                        }
+                        Ok(_update) => { }
                         Err(UnitStatus::Gone) => return Ok(()),
                         _ => continue,
                     }
@@ -74,9 +69,9 @@ impl LocalExceptions {
                 }
             }
 
-            if let (true, Some(data)) = (ready, data.as_ref()) {
+            if let (true, Some(data)) = (ready, self.source.get_data()) {
                 gate.update_data(
-                    files.apply(component.name(), data.clone())
+                    files.apply(component.name(), data)
                 ).await;
             }
         }
@@ -120,8 +115,8 @@ impl ExceptionSet {
         res
     }
 
-    fn apply(&self, unit: &str, update: payload::Update) -> payload::Update {
-        let mut set = update.into_set();
+    fn apply(&self, unit: &str, update: &payload::Update) -> payload::Update {
+        let mut set = update.set().clone();
 
         for (path, file) in
             self.data.paths.iter().zip(self.data.files.iter())


### PR DESCRIPTION
This PR changes some aspect of the communication module to deal with startup and shutdown of units.

In order to allow a unit or target that is started after an upstream unit and misses updates to gain access to the last update, a gate will store the last update and include it in its response to the subscription request. A consequence of this is that the last update of every unit will be kept around. In most cases, they need to be kept around, anyway – the _rtr_ unit needs it for diffing, the _any_ unit needs to keep the updates for all its sources so it can seamlessly switch –, so this shouldn’t have too much of an impact in practice.

The PR also fixes an issue when shutting down units. In this case, the link goes into a “gone” state. Querying the link  was immediately returning with the gone state. If the unit owning the link was looping over this link query, it would just end up in an endless, uninterrupted loop which would take over one of the threads of the Tokio runtime. This is fixed by having `Link::query` not return in case the status is “gone” but rather just remain in pending state forever.

In addition, the PR does a change the the handling of suspending a link. Earlier, querying the link would un-suspend it (or rather, that was the intention, I believe it didn’t actually do that). Now suspending and unsuspending is just a state change communicated to the gate which then can in turn report this to its unit for further consideration.

Finally, the PR adds both a test unit and a test target as well as changes the manager to allow setting up a unit graph programmatically. This way, test cases with unit graphs can be written and their behaviour asserted.

