### PR TITLE
Combine payload update and setting healthy status.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,25 +276,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_filter"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
-dependencies = [
- "log",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
-dependencies = [
- "env_filter",
- "log",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,6 +579,17 @@ name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "itoa"
@@ -913,7 +905,6 @@ dependencies = [
  "clap",
  "crossbeam-utils",
  "daemonbase",
- "env_logger",
  "futures",
  "hyper",
  "log",
@@ -927,6 +918,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slab",
+ "stderrlog",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
@@ -1078,6 +1070,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "stderrlog"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c910772f992ab17d32d6760e167d2353f4130ed50e796752689556af07dc6b"
+dependencies = [
+ "chrono",
+ "is-terminal",
+ "log",
+ "termcolor",
+ "thread_local",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1132,6 +1137,25 @@ checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -1496,6 +1520,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,15 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,21 +82,21 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b3d0060af21e8d11a926981cc00c6c1541aa91dd64b9f881985c3da1094425f"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line",
  "cc",
@@ -152,9 +143,9 @@ checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cc"
@@ -291,7 +282,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
 dependencies = [
  "log",
- "regex",
 ]
 
 [[package]]
@@ -300,10 +290,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
 dependencies = [
- "anstream",
- "anstyle",
  "env_filter",
- "humantime",
  "log",
 ]
 
@@ -526,12 +513,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "hyper"
 version = "0.14.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,9 +585,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.5"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -620,9 +601,9 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
@@ -831,35 +812,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
-
-[[package]]
 name = "reqwest"
 version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1058,9 +1010,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "itoa",
  "ryu",
@@ -1099,9 +1051,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
@@ -1133,9 +1085,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "2.0.53"
+version = "2.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
+checksum = "002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1302,7 +1254,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.8",
+ "toml_edit 0.22.9",
 ]
 
 [[package]]
@@ -1327,9 +1279,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.8"
+version = "0.22.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c12219811e0c1ba077867254e5ad62ee2c9c190b0d957110750ac0cda1ae96cd"
+checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
 dependencies = [
  "indexmap",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,6 +285,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,6 +524,12 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -793,6 +831,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+
+[[package]]
 name = "reqwest"
 version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -894,6 +961,7 @@ dependencies = [
  "clap",
  "crossbeam-utils",
  "daemonbase",
+ "env_logger",
  "futures",
  "hyper",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ url             = { version = "2.2", features = ["serde"] }
 webpki-roots    = "0.25.2"
 
 [dev-dependencies]
-env_logger      = "0.11"
+env_logger      = { version = "0.11", default-features = false }
 rand_pcg        = "0.3"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ url             = { version = "2.2", features = ["serde"] }
 webpki-roots    = "0.25.2"
 
 [dev-dependencies]
-env_logger      = { version = "0.11", default-features = false }
+stderrlog       = "0.6"
 rand_pcg        = "0.3"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ url             = { version = "2.2", features = ["serde"] }
 webpki-roots    = "0.25.2"
 
 [dev-dependencies]
+env_logger      = "0.11"
 rand_pcg        = "0.3"
 
 [profile.release]

--- a/src/comms.rs
+++ b/src/comms.rs
@@ -73,9 +73,6 @@ pub struct Gate {
     /// The current unit status.
     unit_status: UnitStatus,
 
-    /// The last update from the unit if there was one.
-    unit_data: Option<payload::Update>,
-
     /// The gate metrics.
     metrics: Arc<GateMetrics>,
 }
@@ -93,8 +90,7 @@ impl Gate {
             commands: rx,
             updates: Slab::new(),
             suspended: 0,
-            unit_status: UnitStatus::default(),
-            unit_data: None,
+            unit_status: Default::default(),
             metrics: Default::default(),
         };
         let agent = GateAgent { commands: tx };
@@ -162,19 +158,23 @@ impl Gate {
         }
     }
 
-    /// Updates the data set of the unit.
+    /// Updates the unit.
     ///
     /// This method will send out the update to all active links. It will
     /// also update the gate metrics based on the update.
-    pub async fn update_data(&mut self, update: payload::Update) {
-        self.unit_data = Some(update.clone());
+    ///
+    /// Returns whether the update changed the unit’s status.
+    pub async fn update(&mut self, update: UnitUpdate) -> bool {
+        if !self.unit_status.apply(&update) {
+            return false
+        }
         for (_, item) in &mut self.updates {
             if item.suspended {
                 continue
             }
             match item.sender.as_mut() {
                 Some(sender) => {
-                    if sender.send(Ok(update.clone())).await.is_ok() {
+                    if sender.send(update.clone()).await.is_ok() {
                         continue
                     }
                 }
@@ -183,32 +183,8 @@ impl Gate {
             item.sender = None
         }
         self.updates.retain(|_, item| item.sender.is_some());
-        self.metrics.update(&update);
-    }
-
-    /// Updates the unit status.
-    ///
-    /// The method sends out the new status to all links.
-    ///
-    /// If the current status is already the status to set, does nothing.
-    pub async fn update_status(&mut self, update: UnitStatus) {
-        if self.unit_status == update {
-            return
-        }
-        self.unit_status = update;
-        for (_, item) in &mut self.updates {
-            match item.sender.as_mut() {
-                Some(sender) => {
-                    if sender.send(Err(update)).await.is_ok() {
-                        continue
-                    }
-                }
-                None => continue
-            }
-            item.sender = None
-        }
-        self.updates.retain(|_, item| item.sender.is_some());
-        self.metrics.update_status(update);
+        self.metrics.update(&self.unit_status);
+        true
     }
 
     /// Returns the current gate status.
@@ -242,8 +218,7 @@ impl Gate {
         let subscription = SubscribeResponse {
             slot,
             receiver,
-            unit_status: self.unit_status,
-            unit_data: self.unit_data.clone(),
+            unit_status: self.unit_status.clone(),
         };
         if let Err(subscription) = response.send(subscription) {
             self.updates.remove(subscription.slot);
@@ -286,7 +261,7 @@ impl GateAgent {
 #[derive(Debug, Default)]
 pub struct GateMetrics {
     /// The current unit status.
-    status: AtomicCell<UnitStatus>,
+    status: AtomicCell<UnitHealth>,
 
     /// The number of payload items in the last update.
     count: AtomicUsize,
@@ -299,14 +274,14 @@ pub struct GateMetrics {
 
 impl GateMetrics {
     /// Updates the metrics to match the given update.
-    fn update(&self, update: &payload::Update) {
-        self.count.store(update.set().len(), atomic::Ordering::Relaxed);
+    fn update(&self, status: &UnitStatus) {
+        if let Some(payload) = status.payload.as_ref() {
+            self.count.store(
+                payload.set().len(), atomic::Ordering::Relaxed
+            );
+        }
         self.update.store(Some(Utc::now()));
-    }
-
-    /// Updates the metrics to match the given unit status.
-    fn update_status(&self, status: UnitStatus) {
-        self.status.store(status)
+        self.status.store(status.health)
     }
 }
 
@@ -392,11 +367,8 @@ pub struct Link {
     /// The connection to the unit.
     connection: ConnectionStatus,
 
-    /// The current unit status.
+    /// The current unit health.
     unit_status: UnitStatus,
-
-    /// The last update of the unit if any.
-    unit_data: Option<payload::Update>,
 
     /// Are we currently suspended?
     suspended: bool,
@@ -429,20 +401,19 @@ impl Link {
         Link {
             commands,
             connection: ConnectionStatus::Unconnected,
-            unit_status: UnitStatus::Healthy,
-            unit_data: None,
+            unit_status: Default::default(),
             suspended: false,
         }
     }
 
-    /// Returns the current status of the connected unit.
-    pub fn get_status(&self) -> UnitStatus {
-        self.unit_status
+    /// Returns the current health of the connected unit.
+    pub fn get_health(&self) -> UnitHealth {
+        self.unit_status.health
     }
 
     /// Returns the last update if there was one.
-    pub fn get_data(&self) -> Option<&payload::Update> {
-        self.unit_data.as_ref()
+    pub fn get_payload(&self) -> Option<&payload::Update> {
+        self.unit_status.payload.as_ref()
     }
 
     /// Query for the next update.
@@ -450,21 +421,15 @@ impl Link {
     /// The method returns a future that resolves into the next update. The
     /// future can be dropped safely at any time.
     ///
-    /// The future either resolves into a payload update or the connected
-    /// unit’s new status as the error variant.
-    ///
     /// If this method is called when the unit status is “gone,” the future
     /// will never resolve.
-    pub async fn query(&mut self) -> Result<&payload::Update, UnitStatus> {
+    pub async fn query(&mut self) -> UnitUpdate {
         if self.connect().await {
-            if !matches!(self.unit_status, UnitStatus::Healthy) {
-                return Err(self.unit_status)
-            }
-            // No if let because of lifetime issues.
-            #[allow(clippy::single_match)]
-            match self.unit_data {
-                Some(ref update) => return Ok(update),
-                None => {}
+            // A connection attempt has been made. The unit status now
+            // represents the initial update. If there is one, return it.
+            // Otherwise we need to wait for the next real update.
+            if let Some(update) = self.unit_status.to_update() {
+                return update
             }
         }
 
@@ -475,25 +440,21 @@ impl Link {
             }
         };
         match conn.updates.recv().await {
-            Some(Ok(update)) => {
-                self.unit_data = Some(update);
-                Ok(self.unit_data.as_ref().unwrap())
-            }
-            Some(Err(status)) => {
-                self.unit_status = status;
-                Err(status)
+            Some(update) => {
+                self.unit_status.apply(&update);
+                update
             }
             None => {
                 self.connection = ConnectionStatus::Gone;
-                self.unit_status = UnitStatus::Gone;
-                Err(UnitStatus::Gone)
+                self.unit_status.health = UnitHealth::Gone;
+                UnitUpdate::Gone
             }
         }
     }
 
     /// Connects the link to the gate if necessary.
     ///
-    /// Returns `true` if a connection attemptwas made – independently of
+    /// Returns `true` if a connection attempt was made – independently of
     /// whether that was successfull or not – or `false` otherwise.
     async fn connect(&mut self) -> bool {
         if !matches!(self.connection, ConnectionStatus::Unconnected) {
@@ -505,14 +466,14 @@ impl Link {
             GateCommand::Subscribe { suspended: self.suspended, response: tx }
         ).await.is_err() {
             self.connection = ConnectionStatus::Gone;
-            self.unit_status = UnitStatus::Gone;
+            self.unit_status.health = UnitHealth::Gone;
             return true
         }
         let sub = match rx.await {
             Ok(sub) => sub,
             Err(_) => {
                 self.connection = ConnectionStatus::Gone;
-                self.unit_status = UnitStatus::Gone;
+                self.unit_status.health = UnitHealth::Gone;
                 return true
             }
         };
@@ -521,7 +482,6 @@ impl Link {
             updates: sub.receiver,
         });
         self.unit_status = sub.unit_status;
-        self.unit_data = sub.unit_data;
         true
     }
 
@@ -544,7 +504,7 @@ impl Link {
                 slot: conn.slot,
                 suspend
             }).await.is_err() {
-                self.unit_status = UnitStatus::Gone
+                self.unit_status.health = UnitHealth::Gone
             }
             else {
                 self.suspended = suspend
@@ -592,11 +552,11 @@ pub enum GateStatus {
 }
 
 
-//------------ UnitStatus ----------------------------------------------------
+//------------ UnitHealth ----------------------------------------------------
 
 /// The operational status of a unit.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub enum UnitStatus {
+pub enum UnitHealth {
     /// The unit is ready to produce data updates.
     ///
     /// Note that this status does not necessarily mean that the unit is
@@ -620,14 +580,114 @@ pub enum UnitStatus {
     Gone,
 }
 
-impl fmt::Display for UnitStatus {
+impl<'a> From<&'a UnitUpdate> for UnitHealth {
+    fn from(update: &'a UnitUpdate) -> Self {
+        match update {
+            UnitUpdate::Payload(_) => Self::Healthy,
+            UnitUpdate::Stalled => Self::Stalled,
+            UnitUpdate::Gone => Self::Gone,
+        }
+    }
+}
+
+impl fmt::Display for UnitHealth {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(match *self {
-            UnitStatus::Healthy => "healthy",
-            UnitStatus::Stalled => "stalled",
-            UnitStatus::Gone => "gone",
+            UnitHealth::Healthy => "healthy",
+            UnitHealth::Stalled => "stalled",
+            UnitHealth::Gone => "gone",
         })
     }
+}
+
+
+//------------ UnitStatus ----------------------------------------------------
+
+/// A combination of both a unit’s health and the last payload update.
+///
+/// This is a helper type that makes it easier to apply updates.
+#[derive(Clone, Debug, Default)]
+struct UnitStatus {
+    /// The current health of the unit.
+    health: UnitHealth,
+
+    /// The last payload update if there ever was one.
+    payload: Option<payload::Update>,
+}
+
+impl UnitStatus {
+    /// Applies a unit update to the status.
+    ///
+    /// Returns whether the status has changed.
+    fn apply(&mut self, update: &UnitUpdate) -> bool {
+        match update {
+            UnitUpdate::Payload(payload) => {
+                if matches!(self.health, UnitHealth::Healthy)
+                    && Some(payload) == self.payload.as_ref()
+                {
+                    false
+                }
+                else {
+                    self.health = UnitHealth::Healthy;
+                    self.payload = Some(payload.clone());
+                    true
+                }
+            }
+            UnitUpdate::Stalled => {
+                if matches!(self.health, UnitHealth::Stalled) {
+                    false
+                }
+                else {
+                    self.health = UnitHealth::Stalled;
+                    true
+                }
+            }
+            UnitUpdate::Gone => {
+                if matches!(self.health, UnitHealth::Gone) {
+                    false
+                }
+                else {
+                    self.health = UnitHealth::Gone;
+                    true
+                }
+            }
+        }
+    }
+
+    /// Returns an update corresponding with the current unit status.
+    ///
+    /// This may be `None` if the unit status indicates that there hasn’t
+    /// been an update yet.
+    fn to_update(&self) -> Option<UnitUpdate> {
+        match self.health {
+            UnitHealth::Healthy => {
+                self.payload.as_ref().map(|payload| {
+                    UnitUpdate::Payload(payload.clone())
+                })
+            }
+            UnitHealth::Stalled => Some(UnitUpdate::Stalled),
+            UnitHealth::Gone => Some(UnitUpdate::Gone),
+        }
+    }
+}
+
+
+//------------ UnitUpdate ----------------------------------------------------
+
+/// An update to the unit.
+#[derive(Clone, Debug)]
+pub enum UnitUpdate {
+    /// A new payload set has become available.
+    ///
+    /// This also implies a change to unit status “healthy” if that is not the
+    /// current state.
+    Payload(payload::Update),
+
+    /// The unit status has changed to “stalled.”
+    Stalled,
+
+    /// The unit status has changed to “gone.”
+    Gone
 }
 
 
@@ -678,7 +738,7 @@ struct UpdateSender {
     /// fails, we swap this to `None` and then go over the slab again and
     /// drop anything that is `None`. We need to do this because
     /// `Slab::retain` isn’t async but `mpsc::Sender::send` is.
-    sender: Option<mpsc::Sender<Result<payload::Update, UnitStatus>>>,
+    sender: Option<mpsc::Sender<UnitUpdate>>,
 
     /// Are we currently suspended?
     suspended: bool
@@ -688,7 +748,7 @@ struct UpdateSender {
 //------------ UpdateReceiver ------------------------------------------------
 
 /// The link side of receiving updates.
-type UpdateReceiver = mpsc::Receiver<Result<payload::Update, UnitStatus>>;
+type UpdateReceiver = mpsc::Receiver<UnitUpdate>;
 
 
 //------------ SubscribeResponse ---------------------------------------------
@@ -704,8 +764,5 @@ struct SubscribeResponse {
 
     /// The current unit status.
     unit_status: UnitStatus,
-
-    /// The last update of the unit if any.
-    unit_data: Option<payload::Update>,
 }
 

--- a/src/targets/http.rs
+++ b/src/targets/http.rs
@@ -13,7 +13,7 @@ use log::debug;
 use rpki::rtr::State;
 use serde::Deserialize;
 use crate::payload;
-use crate::comms::Link;
+use crate::comms::{Link, UnitUpdate};
 use crate::formats::output;
 use crate::manager::Component;
 use crate::utils::http::EtagsIter;
@@ -90,14 +90,14 @@ impl Target {
 
         loop {
             debug!("Target {}: link status: {}",
-                    component.name(), unit.get_status()
+                    component.name(), unit.get_health()
             );
-            if let Ok(update) = unit.query().await {
+            if let UnitUpdate::Payload(update) = unit.query().await {
                 debug!(
                     "Target {}: Got update ({} entries)",
                     component.name(), update.set().len()
                 );
-                source.update(SourceData::new(update, &mut state));
+                source.update(SourceData::new(&update, &mut state));
             }
         }
     }

--- a/src/targets/http.rs
+++ b/src/targets/http.rs
@@ -90,7 +90,7 @@ impl Target {
 
         loop {
             debug!("Target {}: link status: {}",
-                    component.name(), unit.get_health()
+                    component.name(), unit.health()
             );
             if let UnitUpdate::Payload(update) = unit.query().await {
                 debug!(

--- a/src/targets/rtr.rs
+++ b/src/targets/rtr.rs
@@ -24,7 +24,7 @@ use tokio_rustls::rustls::{Certificate, PrivateKey, ServerConfig};
 use tokio_rustls::server::TlsStream;
 use tokio_stream::wrappers::TcpListenerStream;
 use crate::payload;
-use crate::comms::Link;
+use crate::comms::{Link, UnitUpdate};
 use crate::manager::Component;
 
 
@@ -52,20 +52,32 @@ impl Tcp {
     }
 
     /// Runs the target.
-    pub async fn run(mut self, component: Component) -> Result<(), ExitError> {
-        let mut notify = NotifySender::new();
+    pub async fn run(self, component: Component) -> Result<(), ExitError> {
+        let notify = NotifySender::new();
         let target = Source::new(self.history_size);
         for &addr in &self.listen {
             self.spawn_listener(addr, target.clone(), notify.clone())?;
         }
 
+        self.run_loop(component, target, notify).await
+    }
+
+    /// Runs the target’s main loop.
+    async fn run_loop(
+        mut self,
+        component: Component,
+        target: Source,
+        mut notify: NotifySender
+    ) -> Result<(), ExitError> {
         loop {
-            if let Ok(update) = self.unit.query().await {
+            let update = self.unit.query().await;
+            if let UnitUpdate::Payload(ref payload) = update {
                 debug!(
                     "Target {}: Got update ({} entries)",
-                    component.name(), update.set().len()
+                    component.name(), payload.set().len()
                 );
-                target.update(update);
+            }
+            if target.update(update) {
                 notify.notify()
             }
         }
@@ -127,9 +139,9 @@ pub struct Tls {
 
 impl Tls {
     /// Runs the target.
-    pub async fn run(mut self, component: Component) -> Result<(), ExitError> {
+    pub async fn run(self, component: Component) -> Result<(), ExitError> {
         let acceptor = TlsAcceptor::from(Arc::new(self.create_tls_config()?));
-        let mut notify = NotifySender::new();
+        let notify = NotifySender::new();
         let target = Source::new(self.tcp.history_size);
         for &addr in &self.tcp.listen {
             self.spawn_listener(
@@ -137,16 +149,7 @@ impl Tls {
             )?;
         }
 
-        loop {
-            if let Ok(update) = self.tcp.unit.query().await {
-                debug!(
-                    "Target {}: Got update ({} entries)",
-                    component.name(), update.set().len()
-                );
-                target.update(update);
-                notify.notify()
-            }
-        }
+        self.tcp.run_loop(component, target, notify).await
     }
 
     /// Creates the TLS server config.
@@ -274,23 +277,27 @@ impl Source {
         }
     }
 
-    fn update(&self, update: &payload::Update) {
-        let data = self.data.load();
+    fn update(&self, update: UnitUpdate) -> bool {
+        let payload = match update {
+            UnitUpdate::Payload(payload) => payload,
+            _ => return false,
+        };
 
+        let data = self.data.load();
         let new_data = match data.current.as_ref() {
             None => {
                 SourceData {
                     state: data.state,
-                    current: Some(update.set().clone()),
+                    current: Some(payload.set().clone()),
                     diffs: Vec::new(),
                     timing: Timing::default(),
                 }
             }
             Some(current) => {
-                let diff = update.set().diff_from(current);
+                let diff = payload.set().diff_from(current);
                 if diff.is_empty() {
                     // If there is no change in data, don’t update.
-                    return
+                    return false
                 }
                 let mut diffs = Vec::with_capacity(
                     cmp::min(data.diffs.len() + 1, self.history_size)
@@ -309,7 +316,7 @@ impl Source {
                 state.inc();
                 SourceData {
                     state,
-                    current: Some(update.set().clone()),
+                    current: Some(payload.set().clone()),
                     diffs,
                     timing: Timing::default(),
                 }
@@ -317,6 +324,7 @@ impl Source {
         };
 
         self.data.store(new_data.into());
+        true
     }
 }
 

--- a/src/targets/rtr.rs
+++ b/src/targets/rtr.rs
@@ -263,13 +263,18 @@ impl Tls {
 
 //------------ Source --------------------------------------------------------
 
+/// The data source for the RTR client.
 #[derive(Clone)]
 struct Source {
+    /// The current data set.
     data: Arc<ArcSwap<SourceData>>,
+
+    /// The maximum nummber of diffs to keep.
     history_size: usize,
 }
 
 impl Source {
+    /// Creates a new source using the given history size.
     fn new(history_size: usize) -> Self {
         Source {
             data: Default::default(),
@@ -277,6 +282,9 @@ impl Source {
         }
     }
 
+    /// Updates the source from the provided unit update.
+    ///
+    /// Returns whether there is a new data set and clients need notifying.
     fn update(&self, update: UnitUpdate) -> bool {
         let payload = match update {
             UnitUpdate::Payload(payload) => payload,
@@ -367,6 +375,7 @@ impl PayloadSource for Source {
 
 //------------ SourceData ----------------------------------------------------
 
+/// The RTR data set.
 #[derive(Clone, Default)]
 struct SourceData {
     /// The current RTR state of the target.
@@ -385,6 +394,7 @@ struct SourceData {
 }
 
 impl SourceData {
+    /// Returns the diff for the given serial if available.
     fn get_diff(&self, serial: Serial) -> Option<payload::OwnedDiffIter> {
         if serial == self.state.serial() {
             Some(payload::Diff::default().into_owned_iter())

--- a/src/test.rs
+++ b/src/test.rs
@@ -114,7 +114,7 @@ impl TargetController {
             }
             Err(TryRecvError::Empty) => Ok(()),
             Err(TryRecvError::Disconnected) => {
-                Err(format!("target disconnected"))
+                Err("target disconnected".to_string())
             }
         }
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -100,6 +100,20 @@ pub struct TargetController {
 }
 
 impl TargetController {
+    pub fn recv_nothing(&mut self) {
+        use tokio::sync::mpsc::error::TryRecvError;
+
+        match self.rx.try_recv() {
+            Ok(update) => {
+                panic!("expected no update, got {:?}", update);
+            }
+            Err(TryRecvError::Empty) => { }
+            Err(TryRecvError::Disconnected) => {
+                panic!("target disconnected")
+            }
+        }
+    }
+
     pub async fn recv(&mut self) -> UnitUpdate {
         self.rx.recv().await.unwrap()
     }
@@ -107,14 +121,14 @@ impl TargetController {
     pub async fn recv_payload(&mut self) -> payload::Update {
         match self.recv().await {
             UnitUpdate::Payload(payload) => payload,
-            other => panic!("Expected payload, got {:?}", other),
+            other => panic!("expected payload, got {:?}", other),
         }
     }
 
     pub async fn recv_stalled(&mut self) {
         match self.recv().await {
             UnitUpdate::Stalled => { }
-            other => panic!("Expected stalled status, got {:?}", other),
+            other => panic!("expected stalled status, got {:?}", other),
         }
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -123,12 +123,7 @@ impl TargetController {
 //------------ Helper Functions ----------------------------------------------
 
 pub fn init_log() {
-    use std::io::Write;
-
-    env_logger::Builder::new()
-        .filter_level(log::LevelFilter::max())
-        .format(|buf, record| writeln!(buf, "{}", record.args()))
-        .init();
+    stderrlog::new().verbosity(5).init().unwrap();
 }
 
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -120,6 +120,18 @@ impl TargetController {
 }
 
 
+//------------ Helper Functions ----------------------------------------------
+
+pub fn init_log() {
+    use std::io::Write;
+
+    env_logger::Builder::new()
+        .filter_level(log::LevelFilter::max())
+        .format(|buf, record| writeln!(buf, "{}", record.args()))
+        .init();
+}
+
+
 //============ Tests =========================================================
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src/units/combine.rs
+++ b/src/units/combine.rs
@@ -233,24 +233,34 @@ mod test {
             }
         ).unwrap();
 
+        eprintln!("All stalled");
         // Set all units to stalled, check that the target goes stalled.
         join!(u1.send_stalled(), u2.send_stalled(), u3.send_stalled());
+        eprintln!("Check");
         t.recv_stalled().await;
 
+        eprintln!("u2 update");
         // Set one unit to healthy.
-        u2.send_payload(testrig::update(&[1])).await;
+        u2.send_payload(testrig::update(&[2])).await;
+        eprintln!("Check");
         assert_eq!(t.recv_payload().await, testrig::update(&[1]));
 
+        eprintln!("u1 update");
         // Set another unit to healthy. This shouldn’t change anything.
-        u1.send_payload(testrig::update(&[2])).await;
+        u1.send_payload(testrig::update(&[1])).await;
+        eprintln!("Check");
         t.recv_nothing();
 
+        eprintln!("u1 and u2 stalled");
         // Stall them both again.
         join!(u1.send_stalled(), u2.send_stalled());
+        eprintln!("Check");
         t.recv_stalled().await;
 
+        eprintln!("u3 update");
         // Now unstall one again.
         u3.send_payload(testrig::update(&[3])).await;
+        eprintln!("Check");
         assert_eq!(t.recv_payload().await, testrig::update(&[3]));
     }
 }

--- a/src/units/combine.rs
+++ b/src/units/combine.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 use crossbeam_utils::atomic::AtomicCell;
 use futures::future::{select, select_all, Either, FutureExt};
+use log::debug;
 use rand::{thread_rng, Rng};
 use serde::Deserialize;
 use crate::metrics;
@@ -47,6 +48,10 @@ impl Any {
                     return Err(Terminated)
                 }
             };
+            debug!(
+                "Unit {}: current index is now {:?}",
+                component.name(), curr_idx
+            );
             metrics.current_index.store(curr_idx);
             match curr_idx {
                 Some(idx) => {

--- a/src/units/combine.rs
+++ b/src/units/combine.rs
@@ -243,6 +243,7 @@ mod test {
 
         // Set another unit to healthy. This shouldn’t change anything.
         u1.send_payload(testrig::update(&[2])).await;
+        t.recv_nothing();
 
         // Stall them both again.
         join!(u1.send_stalled(), u2.send_stalled());

--- a/src/units/combine.rs
+++ b/src/units/combine.rs
@@ -237,31 +237,31 @@ mod test {
         // Set all units to stalled, check that the target goes stalled.
         join!(u1.send_stalled(), u2.send_stalled(), u3.send_stalled());
         eprintln!("Check");
-        t.recv_stalled().await;
+        t.recv_stalled().await.unwrap();
 
         eprintln!("u2 update");
         // Set one unit to healthy.
         u2.send_payload(testrig::update(&[2])).await;
         eprintln!("Check");
-        assert_eq!(t.recv_payload().await, testrig::update(&[2]));
+        assert_eq!(t.recv_payload().await.unwrap(), testrig::update(&[2]));
 
         eprintln!("u1 update");
         // Set another unit to healthy. This shouldn’t change anything.
         u1.send_payload(testrig::update(&[1])).await;
         eprintln!("Check");
-        t.recv_nothing();
+        t.recv_nothing().unwrap();
 
         eprintln!("u1 and u2 stalled");
         // Stall them both again.
         join!(u1.send_stalled(), u2.send_stalled());
         eprintln!("Check");
-        t.recv_stalled().await;
+        t.recv_stalled().await.unwrap();
 
         eprintln!("u3 update");
         // Now unstall one again.
         u3.send_payload(testrig::update(&[3])).await;
         eprintln!("Check");
-        assert_eq!(t.recv_payload().await, testrig::update(&[3]));
+        assert_eq!(t.recv_payload().await.unwrap(), testrig::update(&[3]));
     }
 }
 

--- a/src/units/combine.rs
+++ b/src/units/combine.rs
@@ -208,6 +208,7 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn wake_up_again() {
+        test::init_log();
         let mut manager = Manager::new();
 
         let (u1, u2, u3, mut t) = manager.add_components(

--- a/src/units/combine.rs
+++ b/src/units/combine.rs
@@ -205,7 +205,7 @@ mod test {
     use crate::manager::Manager;
     use crate::payload::testrig;
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn wake_up_again() {
         test::init_log();
         let mut manager = Manager::new();

--- a/src/units/combine.rs
+++ b/src/units/combine.rs
@@ -243,7 +243,7 @@ mod test {
         // Set one unit to healthy.
         u2.send_payload(testrig::update(&[2])).await;
         eprintln!("Check");
-        assert_eq!(t.recv_payload().await, testrig::update(&[1]));
+        assert_eq!(t.recv_payload().await, testrig::update(&[2]));
 
         eprintln!("u1 update");
         // Set another unit to healthy. This shouldn’t change anything.

--- a/src/units/combine.rs
+++ b/src/units/combine.rs
@@ -232,13 +232,17 @@ mod test {
             }
         ).unwrap();
 
-        // Set all units to stalled, check that the target goes stalled after
-        // the last one.
+        // Set one unit to stalled, this triggers picking a new source healthy
+        // with data but there isn’t one, so we go stalled.
         u1.send_stalled().await;
+        t.recv_stalled().await.unwrap();
+
+        // Now stall the other ones. That shouldn’t change anything.
+        // the last one.
         u2.send_stalled().await;
         t.recv_nothing().unwrap();
         u3.send_stalled().await;
-        t.recv_stalled().await.unwrap();
+        t.recv_nothing().unwrap();
 
         // Set one unit to healthy, check that we get an update.
         u1.send_payload(testrig::update(&[1])).await;

--- a/src/units/rtr.rs
+++ b/src/units/rtr.rs
@@ -293,9 +293,7 @@ where
         loop {
             debug!("Unit {}: Connecting ...", target.name);
             let mut client = match this.connect(target, &mut gate).await {
-                Ok(client) => {
-                    client
-                }
+                Ok(client) => client,
                 Err(res) => {
                     debug!(
                         "Unit {}: Connection failed. Awaiting reconnect.",

--- a/src/units/slurm.rs
+++ b/src/units/slurm.rs
@@ -72,7 +72,7 @@ impl LocalExceptions {
                 }
             }
 
-            if let (true, Some(data)) = (ready, self.source.get_payload()) {
+            if let (true, Some(data)) = (ready, self.source.payload()) {
                 gate.update(
                     UnitUpdate::Payload(files.apply(component.name(), data))
                 ).await;


### PR DESCRIPTION
This PR revises how updates are dispatched. Instead of having separate status and payload updates, these are now merged into one with a payload update implying a status change to healthy. This should avoid the potential for strange races between setting the status back to healthy and updating the data. 

A resulting limitation is that if a unit wants to change from stalled to healthy it has to submit a payload update, but in practice this health status change is pretty much always triggered by a new payload update becoming available, so this should be fine.

This is a breaking change.