### PR TITLE
Additional config options for the HTTP client.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,6 +267,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -835,6 +841,7 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-rustls",
+ "tokio-socks",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -1149,6 +1156,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1241,6 +1268,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51165dfa029d2a65969413a6cc96f354b86b464498702f174a4efa13608fd8c0"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,11 @@ toml            = "0.8.2"
 url             = { version = "2.2", features = ["serde"] }
 webpki-roots    = "0.25.2"
 
+[features]
+default = [ "socks" ]
+socks = [ "reqwest/socks" ]
+
+
 [dev-dependencies]
 stderrlog       = "0.6"
 rand_pcg        = "0.3"

--- a/doc/manual/source/configuration.rst
+++ b/doc/manual/source/configuration.rst
@@ -45,6 +45,9 @@ Note that details are provided for each unit and each target.
     http-listen = ["127.0.0.1:8080"]
 
     # The proxy servers to use for outgoing HTTP requests.
+    #
+    # Note: This option is only used if RTRTR is built with the socks feature
+    # enabled. This is true by default.
     http-proxies = [ "socks5://192.168.1.3:9000" ]
 
     # Additional root certificates for outgoing HTTP requests

--- a/doc/manual/source/configuration.rst
+++ b/doc/manual/source/configuration.rst
@@ -44,6 +44,18 @@ Note that details are provided for each unit and each target.
     # Where should the HTTP server listen on?
     http-listen = ["127.0.0.1:8080"]
 
+    # The proxy servers to use for outgoing HTTP requests.
+    http-proxies = [ "socks5://192.168.1.3:9000" ]
+
+    # Additional root certificates for outgoing HTTP requests
+    http-root-certs = [ "/var/lib/rtrtr/root-cert/some.crt" ]
+
+    # The user agent string to use for outgoing HTTP requests.
+    http-user-agent = "My RPKI proxy"
+
+    # Local address to bind to for outgoing HTTP requests.
+    http-client-addr = "198.168.1.2"
+
 Units
 -----
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,6 @@ use daemonbase::logging::Logger;
 use futures::future::pending;
 use tokio::runtime;
 use rtrtr::config::Config;
-use rtrtr::manager::Manager;
 
 
 fn _main() -> Result<(), ExitError> {
@@ -16,10 +15,7 @@ fn _main() -> Result<(), ExitError> {
         .author(crate_authors!())
         .about("collecting, processing and distributing route filtering data")
     ).get_matches();
-    let mut manager = Manager::new();
-    let mut config = Config::from_arg_matches(
-        &matches, &mut manager
-    )?;
+    let (mut manager, mut config) = Config::from_arg_matches(&matches)?;
     Logger::from_config(&config.log)?.switch_logging(false)?;
     let runtime = runtime::Builder::new_multi_thread()
         .enable_all()

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -37,6 +37,7 @@ pub struct HttpClientConfig {
     user_agent: Option<String>,
 
     /// Local address to bind to for outgoing HTTP requests.
+    #[serde(rename = "http-client-addr")]
     local_addr: Option<IpAddr>,
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -154,7 +154,7 @@ async fn simple_comms() {
     use crate::manager::Manager;
     use crate::payload::testrig;
 
-    let mut manager = Manager::new();
+    let mut manager = Manager::default();
 
     let (u, mut t) = manager.add_components(
         &runtime::Handle::current(),

--- a/src/units/combine.rs
+++ b/src/units/combine.rs
@@ -208,7 +208,7 @@ mod test {
     #[tokio::test]
     async fn wake_up_again() {
         test::init_log();
-        let mut manager = Manager::new();
+        let mut manager = Manager::default();
 
         let (u1, u2, u3, mut t) = manager.add_components(
             &runtime::Handle::current(),


### PR DESCRIPTION
This PR adds four new configuration options for the HTTP client used by the _json_ unit.

These are `http-root-certs` for additional TLS root certificates, `http-user-agent` for setting a custom user agent, `http-client-addr` to specify a local address to bind to, and `http-proxies` to add HTTP proxies. The last option is only available if the `socks` feature is enabled which it is by default.

Fixes #108.