### PR TITLE
Update daemonbase to at least 0.1.2.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,9 +245,9 @@ checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "daemonbase"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f635dcc2d7f5427a17e95a08ae529b7228d1a5f6c902449a6ceb58483bde2f"
+checksum = "1633f8b2a2a1beb427c6719ec89fd428d3503369dc1cc03a283da5a5697ed43b"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ bytes           = "1"
 chrono          = "0.4.31"
 clap            = { version = "~4.4", features = [ "cargo", "derive" ] }
 crossbeam-utils = "0.8.4"
-daemonbase      = "0.1.1"
+daemonbase      = "0.1.2"
 futures-util    = "0.3"
 http-body-util  = "0.1"
 hyper           = { version = "1.3.1", features = [ "server" ] }


### PR DESCRIPTION
This PR update the dependency for deamonbase to at least 0.1.2. This will fix an error in command line handling that resets the log level to “warn” if no options related to the log level are given.

Fixes #120.