### PR TITLE
Update packaging distributions

### DIFF
--- a/pkg/rules/packages-to-build.yml
+++ b/pkg/rules/packages-to-build.yml
@@ -4,11 +4,9 @@
 pkg:
   - "rtrtr"
 image:
-  - "ubuntu:xenial"   # ubuntu/16.04
-  - "ubuntu:bionic"   # ubuntu/18.04
   - "ubuntu:focal"    # ubuntu/20.04
   - "ubuntu:jammy"    # ubuntu/22.04
-  - "debian:stretch"  # debian/9
+  - "ubuntu:noble"    # ubuntu/24.04
   - "debian:buster"   # debian/10
   - "debian:bullseye" # debian/11
   - "debian:bookworm" # debian/12

--- a/pkg/rules/packages-to-build.yml
+++ b/pkg/rules/packages-to-build.yml
@@ -51,9 +51,6 @@ test-mode:
 
 test-exclude:
   - pkg: 'rtrtr'
-    image: 'rockylinux:9'
-    mode: 'upgrade-from-published'
-  - pkg: 'rtrtr'
-    image: 'debian:bookworm'
+    image: 'ubuntu:noble'
     mode: 'upgrade-from-published'
 


### PR DESCRIPTION
This PR removes building of packages for Ubuntu 16.04 and 18.04 and Debian Stretch and adds Ubuntu 24.04.