### PR TITLE
fix: key/cert switchup for rtr-tls target

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,10 +10,14 @@ New
 
 Bug fixes
 
+* Fix rtr-tls target having certificate and key options reversed. ([#133] by [@ember-ana])
+
 Other changes
 
 [#132]: https://github.com/NLnetLabs/rtrtr/pull/132
+[#133]: https://github.com/NLnetLabs/rtrtr/pull/133
 [@devsnek]: https://github.com/devsnek
+[@ember-ana]: https://github.com/ember-ana
 
 
 ## 0.3.1 ‘Some Checks Haven’t Completed Yet’

--- a/src/targets/rtr.rs
+++ b/src/targets/rtr.rs
@@ -151,7 +151,7 @@ impl Tls {
     ) -> Result<(), ExitError> {
         let acceptor = TlsAcceptor::from(Arc::new(
             tls::create_server_config(
-                component.name(), &self.certificate, &self.key
+                component.name(), &self.key, &self.certificate
             )?
         ));
         let notify = NotifySender::new();


### PR DESCRIPTION
when defining a target with `type = "rtr-tls"`, the config keys `certificate` and `key` refer to the respective other

## actual

assuming `test-data/localhost.crt` and `test-data/localhost.key`
```toml
[targets.rtr-tls]
type = "rtr-tls"
certificate = "localhost.crt"
key = "localhost.key"
```
will fail with: `TLS key file 'localhost.crt' does not contain any usable keys.`


meanwhile
```toml
[targets.rtr-tls]
type = "rtr-tls"
key = "localhost.crt"
certificate = "localhost.key"
```
will start successfully


## expected
```toml
[targets.rtr-tls]
type = "rtr-tls"
certificate = "localhost.crt"
key = "localhost.key"
```
should start successfully