### PR TITLE
Upgrade dependencies.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: [1.74.1, stable, beta]
+        rust: [1.81.0, stable, beta]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,8 +411,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -845,7 +857,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -967,8 +979,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
 dependencies = [
  "bytes",
- "getrandom",
- "rand",
+ "getrandom 0.2.15",
+ "rand 0.8.5",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1004,14 +1016,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1021,7 +1049,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1030,16 +1068,25 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.2",
 ]
 
 [[package]]
 name = "rand_pcg"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
+checksum = "b48ac3f7ffaab7fac4d2376632268aa5f89abdb55f7ebf8f4d11fffccb2320f7"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1095,7 +1142,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "spin",
  "untrusted",
@@ -1104,9 +1151,9 @@ dependencies = [
 
 [[package]]
 name = "rpki"
-version = "0.18.5"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20b4c3d0ee54ae5623463c84d032786805f12d139df93539434e45be11db659"
+checksum = "98a043d99463db58c05283f5ae5d9ced858cc3483011747264e21f50b9201cdd"
 dependencies = [
  "arbitrary",
  "base64",
@@ -1141,7 +1188,7 @@ dependencies = [
  "log",
  "nix",
  "pin-project-lite",
- "rand",
+ "rand 0.9.1",
  "rand_pcg",
  "reqwest",
  "rpki",
@@ -1719,6 +1766,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1973,6 +2029,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6f5bb5257f2407a5425c6e749bfd9692192a73e70a6060516ac04f889087d68"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rtrtr"
 version = "0.3.2-dev"
 edition = "2021"
-rust-version = "1.74.1"
+rust-version = "1.81.0"
 authors = ["NLnet Labs <rpki-team@nlnetlabs.nl>"]
 description = "A versatile tool for managing route filters"
 repository = "https://github.com/NLnetLabs/rtrtr"
@@ -24,9 +24,9 @@ hyper           = { version = "1.3.1", features = [ "server" ] }
 hyper-util      = { version = "0.1", features = [ "server", "server-auto", "tokio" ] }
 log             = "0.4"
 pin-project-lite = "0.2.4"
-rand            = "0.8.3"
+rand            = "0.9.1"
 reqwest         = { version = "0.12.5", default-features = false, features = ["blocking", "rustls-tls"] }
-rpki            = { version = "0.18.5", features = ["crypto", "rtr", "slurm"] }
+rpki            = { version = "0.18.6", features = ["crypto", "rtr", "slurm"] }
 rustls-pemfile  = "2.1.2"
 serde           = { version = "1", features = ["derive"] }
 serde_json      = "1"
@@ -47,7 +47,7 @@ socks = [ "reqwest/socks" ]
 
 [dev-dependencies]
 stderrlog       = "0.6"
-rand_pcg        = "0.3"
+rand_pcg        = "0.9"
 
 [profile.release]
 panic = "abort"

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -1483,7 +1483,7 @@ mod test {
         fn random_vec<T: Rng>(rng: &mut T, len: usize) -> Vec<Payload> {
             let mut res = Vec::with_capacity(len);
             for _ in 0..len {
-                res.push(p(rng.gen()))
+                res.push(p(rng.random()))
             }
             res
         }

--- a/src/units/combine.rs
+++ b/src/units/combine.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use crossbeam_utils::atomic::AtomicCell;
 use futures_util::future::{select, select_all, Either, FutureExt};
 use log::debug;
-use rand::{thread_rng, Rng};
+use rand::Rng;
 use serde::Deserialize;
 use crate::{metrics, payload};
 use crate::metrics::{Metric, MetricType, MetricUnit};
@@ -126,7 +126,7 @@ impl Any {
         // source at random and then loop around. That’s not truly random but
         // deterministic.
         let mut next = if self.random {
-            thread_rng().gen_range(0..self.sources.len())
+            rand::rng().random_range(0..self.sources.len())
         }
         else if let Some(curr) = curr {
             (curr + 1) % self.sources.len()

--- a/src/units/slurm.rs
+++ b/src/units/slurm.rs
@@ -283,7 +283,7 @@ mod test {
         fn random_pack<T: Rng>(rng: &mut T, len: usize) -> payload::Pack {
             let mut res = payload::PackBuilder::empty();
             for _ in 0..len {
-                res.insert_unchecked(testrig::p(rng.gen()))
+                res.insert_unchecked(testrig::p(rng.random()))
             }
             res.finalize()
         }
@@ -322,7 +322,8 @@ mod test {
                         _ => None
                     }
                 }).collect(),
-                bgpsec: Vec::new()
+                bgpsec: Vec::new(),
+                aspa: None,
             },
             assertions: p3
         };


### PR DESCRIPTION
This PR upgrades the dependencies for the upcoming 0.3.2 release. Relevant upgrades are rpki-rs for ASPA support and rand.

This PR updates the minimum supported Rust version to 1.81.0.