### PR TITLE
Update merge documentation

### DIFF
--- a/doc/manual/source/configuration.rst
+++ b/doc/manual/source/configuration.rst
@@ -138,6 +138,22 @@ every time it needs to switch or whether it should go through the list in order.
     sources = [ "unit-1", "unit-2", "unit-3" ]
     random = false
 
+Merge Unit
+++++++++++
+
+The ``merge`` unit type is given any number of *other* units and combines
+the data from all of them. This ensures that it uses the data from all data
+sources even if data is (partially) missing from one source.
+
+To configure this unit, specify a name, set the type to ``merge`` and list the
+sources that should be used. 
+
+.. code-block:: text
+
+    [units.any-unit-name]
+    type = "merge"
+    sources = [ "unit-1", "unit-2", "unit-3" ]
+
 SLURM Unit
 ++++++++++
 

--- a/doc/manual/source/configuration.rst
+++ b/doc/manual/source/configuration.rst
@@ -143,7 +143,7 @@ Merge Unit
 
 The ``merge`` unit type is given any number of *other* units and combines
 the data from all of them. This ensures that it uses the data from all data
-sources even if data is (partially) missing from one source.
+sources, in case your router does not support multiple RTR connections.
 
 To configure this unit, specify a name, set the type to ``merge`` and list the
 sources that should be used. 


### PR DESCRIPTION
The `merge` unit is mentioned in the manual page but not the configuration page yet - this PR fixes that. See https://rtrtr--148.org.readthedocs.build/en/148/configuration.html#merge-unit